### PR TITLE
fix: typo in logging message

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -7,7 +7,7 @@ int main(int argc, char* argv[]){
 
     if(argc != 3)
     {
-        printf("[*]Usage: ./add-nbo <file1> <file2>\n");
+        printf("[*] Usage: ./add-nbo <file1> <file2>\n");
         exit(0);
     }
 


### PR DESCRIPTION
I think we need whitespace between ']' and 'U'. 